### PR TITLE
Pipeline cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ defaults: &defaults
   docker:
     - image: circleci/openjdk:8-jdk
   environment:
-    MAVEN_REPO: "../.m2"
     MVN_CMD: "mvn -B --settings=.settings.xml"
 
 jobs:


### PR DESCRIPTION
Caching didn't work due to wrong .m2 repo-path resolution:
`/home/circleci/repo/$MAVEN_REPO` (where `$MAVEN_REPO` pointed to `~/.m2`) instead of `/home/circleci/.m2`

I don't know why this seems to work for everyone else.. i actually copied this from some official page...

BTW i also fixed the slightly broken cache keys: a cache was only identified by it's poms checksum. by this, the cache would have been shared between branches for the same version -> hence, if one installed e.g. the ktor-server-lambda-core on a branch A, another branch B would have used this version A, since it wouldn't have overridden the cache by it's own ktor-server-lambda-core version B.