### PR TITLE
Hotfix to hang issue when response body content length bigger than 4087

### DIFF
--- a/ktor-server-lambda-core/test/LambdaEngineTest.kt
+++ b/ktor-server-lambda-core/test/LambdaEngineTest.kt
@@ -3,6 +3,7 @@ package com.mercateo.ktor.server.lambda
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+import io.kotlintest.matchers.string.shouldHaveLength
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.AnnotationSpec
 import io.ktor.application.*
@@ -18,6 +19,13 @@ fun Application.testApp() {
     routing {
         get("foo") {
             call.respond("bar")
+        }
+        get("large") {
+            val largeResponse = StringBuilder().apply {
+                repeat(8000) { append("a") }
+            }.toString()
+
+            call.respond(largeResponse)
         }
         get("empty") {
             call.respond("")
@@ -52,6 +60,21 @@ class LambdaEngineTest : AnnotationSpec() {
 
         response.statusCode shouldBe 200
         response.body shouldBe "bar"
+    }
+
+    @Test
+    fun `GET request to "large" is answered with large response`() {
+        every { request.path } returns "large"
+        every { request.httpMethod } returns "GET"
+        lateinit var response: APIGatewayProxyResponseEvent
+
+
+        uut.withTestApplication {
+            response = handleRequest(request, context)
+        }
+
+        response.statusCode shouldBe 200
+        response.body shouldHaveLength 8000
     }
 
     @Test


### PR DESCRIPTION
Hey :wave: , I've been using this for my side project and it works great

But I've noticed that when returning responses with a body larger than 4088 it suddenly hangs

I think this is caused by the Ktor BaseApplicationResponse.respondFromBytes

```kotlin
    /**
     * Respond with [bytes] content
     */
    protected open suspend fun respondFromBytes(bytes: ByteArray) {
        headers[HttpHeaders.ContentLength]?.toLong()?.let { length ->
            ensureLength(length, bytes.size.toLong())
        }

        responseChannel().use {
            withContext(Dispatchers.Unconfined) {
                writeFully(bytes)  //<---- this gets suspended indefinitely  
            }
        }
    }
```

I think its due to hitting the ByteBufferChannel buffer capacity, which since output is only getting consumed after `pipeline.execute(call)` , it gets stuck

I've thrown some code together to fix this issue, please take a look :sweat_smile: 