### PR TITLE
Add support for binary response

### DIFF
--- a/ktor-server-lambda-core/test/LambdaEngineTest.kt
+++ b/ktor-server-lambda-core/test/LambdaEngineTest.kt
@@ -3,6 +3,7 @@ package com.mercateo.ktor.server.lambda
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+import io.kotlintest.matchers.string.shouldHaveLength
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.AnnotationSpec
 import io.ktor.application.*
@@ -18,6 +19,13 @@ fun Application.testApp() {
     routing {
         get("foo") {
             call.respond("bar")
+        }
+        get("large") {
+            val largeResponse = StringBuilder().apply {
+                repeat(8000) { append("a") }
+            }.toString()
+
+            call.respond(largeResponse)
         }
         get("empty") {
             call.respond("")
@@ -52,6 +60,21 @@ class LambdaEngineTest : AnnotationSpec() {
 
         response.statusCode shouldBe 200
         response.body shouldBe "bar"
+    }
+
+    @Test
+    fun `GET request to "large" is answered with large response`() {
+        every { request.path } returns "large"
+        every { request.httpMethod } returns "GET"
+        lateinit var response: APIGatewayProxyResponseEvent
+
+
+        uut.withTestApplication {
+            response = handleRequest(request, context)
+        }
+
+        response.statusCode shouldBe 200
+        response.body shouldHaveLength 8000
     }
 
     @Test


### PR DESCRIPTION
This PR builds on top of the work of @Duarte-Figueiredo in #29.

The response bytes are now base 64 encoded by default and added as a `String` to the api-gw response. This means that binary data can be returned successfully from an API!

This addresses #10 